### PR TITLE
added `python-dateutil` requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(
         'Click',
         'requests',
         'colorama',
-        'sgqlc'
+        'sgqlc',
+        'python-dateutil'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
added `python-dateutil` requirement to setup.py

The import line below from `shifter.py` caused new installs to error out.

`from dateutil.relativedelta import relativedelta`